### PR TITLE
Raise custom errors in gzip when response is unexpected

### DIFF
--- a/lib/quickbooks/faraday/middleware/gzip.rb
+++ b/lib/quickbooks/faraday/middleware/gzip.rb
@@ -12,6 +12,9 @@ require 'faraday'
 # - net_http_persistent on Ruby 2.0+
 # - em_http
 class Gzip < Faraday::Middleware
+  class NilResponseEnv < StandardError; end
+  class NilResponseHeaders < StandardError; end
+
   dependency 'zlib'
 
   ACCEPT_ENCODING = 'Accept-Encoding'.freeze
@@ -23,6 +26,9 @@ class Gzip < Faraday::Middleware
   def call(env)
     env[:request_headers][ACCEPT_ENCODING] ||= SUPPORTED_ENCODINGS
     @app.call(env).on_complete do |response_env|
+      raise NilResponseEnv if response_env.nil?
+      raise NilResponseHeaders if response_env[:response_headers].nil?
+
       case response_env[:response_headers][CONTENT_ENCODING]
       when 'gzip'
         reset_body(response_env, &method(:uncompress_gzip))


### PR DESCRIPTION
The line `case response_env[:response_headers][CONTENT_ENCODING]` raises `NoMethodError: undefined method [] for nil:NilClass` sporadically.

It's unclear now whether `response_env` is nil or `response_env[:response_headers]` is nil.

This PR raises custom errors so there can be proper error handling downstream, and more investigation can be done on where the nil error is.