### PR TITLE
Remove standard error

### DIFF
--- a/lib/quickbooks/service/base_service.rb
+++ b/lib/quickbooks/service/base_service.rb
@@ -341,7 +341,7 @@ module Quickbooks
         when 429
           message = parse_intuit_error[:message]
           raise Quickbooks::TooManyRequests, message
-        when 503, 504
+        when 502, 503, 504
           raise Quickbooks::ServiceUnavailable
         else
           raise "HTTP Error Code: #{status}, Msg: #{response.plain_body}"

--- a/lib/quickbooks/service/base_service.rb
+++ b/lib/quickbooks/service/base_service.rb
@@ -344,7 +344,8 @@ module Quickbooks
         when 502, 503, 504
           raise Quickbooks::ServiceUnavailable
         else
-          raise "HTTP Error Code: #{status}, Msg: #{response.plain_body}"
+          ex = Quickbooks::IntuitRequestException.new("HTTP Error Code: #{status}, Msg: #{response.plain_body}")
+          raise ex
         end
       end
 

--- a/spec/lib/quickbooks/service/base_service_spec.rb
+++ b/spec/lib/quickbooks/service/base_service_spec.rb
@@ -139,8 +139,11 @@ describe Quickbooks::Service::BaseService do
       expect { @service.send(:check_response, response) }.to raise_error(Quickbooks::TooManyRequests, message)
     end
 
-    it "should raise ServiceUnavailable on HTTP 503 and 504" do
+    it "should raise ServiceUnavailable on HTTP 502, 503 and 504" do
       xml = fixture('generic_error.xml')
+
+      response = Struct.new(:code, :plain_body).new(502, xml)
+      expect { @service.send(:check_response, response) }.to raise_error(Quickbooks::ServiceUnavailable)
 
       response = Struct.new(:code, :plain_body).new(503, xml)
       expect { @service.send(:check_response, response) }.to raise_error(Quickbooks::ServiceUnavailable)


### PR DESCRIPTION
Wrap the standard error as a `IntuitRequestException` so that we can rescue it correctly

To be merged after >> https://github.com/anaprimawaty/quickbooks-ruby/pull/3