### PR TITLE
Raise empty response headers

### DIFF
--- a/lib/quickbooks/faraday/middleware/gzip.rb
+++ b/lib/quickbooks/faraday/middleware/gzip.rb
@@ -12,8 +12,7 @@ require 'faraday'
 # - net_http_persistent on Ruby 2.0+
 # - em_http
 class Gzip < Faraday::Middleware
-  class NilResponseEnv < StandardError; end
-  class NilResponseHeaders < StandardError; end
+  class EmptyResponseHeaders < StandardError; end
 
   dependency 'zlib'
 
@@ -26,8 +25,7 @@ class Gzip < Faraday::Middleware
   def call(env)
     env[:request_headers][ACCEPT_ENCODING] ||= SUPPORTED_ENCODINGS
     @app.call(env).on_complete do |response_env|
-      raise NilResponseEnv if response_env.nil?
-      raise NilResponseHeaders if response_env[:response_headers].nil?
+      raise EmptyResponseHeaders if response_env[:response_headers].nil?
 
       case response_env[:response_headers][CONTENT_ENCODING]
       when 'gzip'


### PR DESCRIPTION
Based on the logs gathered, `response_env[:response_headers]` is `nil` causing `NoMethodError` to be thrown. Previous: #2